### PR TITLE
fix for CLI timeout setting

### DIFF
--- a/src/unreal4u/pid.php
+++ b/src/unreal4u/pid.php
@@ -288,6 +288,11 @@ class pid
             $this->_setParameters($validParameters, func_get_args());
 
             $this->setFilename($this->_parameters);
+            
+            // if we give the timeout as CLI arg we should actually use it instead of ignoring it
+            if ($timeout === null && isset($this->_parameters['timeout'])) {
+				$timeout = $this->_parameters['timeout'];
+			}
             $this->setTimeout($timeout);
         }
 


### PR DESCRIPTION
Fix for the follow code:
$this->pid = new unreal4u\pid(['directory' => 'data/', 'filename' => CURRENT_SITE_KEY.$prefix.$this->id, 'timeout' => 0]);

The timeout in this case was ignored :(
